### PR TITLE
Show DRC Results Database (.lyrdb) file in KLayout

### DIFF
--- a/klayout/python/klive_server.py
+++ b/klayout/python/klive_server.py
@@ -6,8 +6,6 @@ from typing import Optional
 
 import pya
 
-version = '0.2.3'
-
 _path = Path(__file__).parent.parent
 off = str(_path / "Koff.png")
 live = str(_path / "Klive.png")
@@ -55,8 +53,6 @@ class ServerInstance(pya.QTcpServer):
                     line = connection.readLine()
                     data = json.loads(line)
                     # Interpret the data
-                    if "gds" in data:
-                        gds_path = data["gds"]
                     if "lyrdb" in data:
                         lyrdb_path = data["lyrdb"]
 
@@ -65,7 +61,7 @@ class ServerInstance(pya.QTcpServer):
                     current_view = window.current_view()
                     previous_view = current_view.box() if current_view else None
 
-                    send_data = {"version": version }
+                    send_data = {"version": "0.2.2"}
 
                     def load_existing_layout():
                         for i in range(window.views()):
@@ -156,7 +152,7 @@ class ServerInstance(pya.QTcpServer):
         self.server = server
         if self.action is not None and self.isListening():
             self.action.on_triggered = self.on_action_click
-            print("klive %s is running" %version)
+            print("klive 0.2.2 is running")
             self.action.icon = live
         else:
             print("klive didn't start correctly. Most likely port tcp/8082")
@@ -168,7 +164,7 @@ class ServerInstance(pya.QTcpServer):
     def close(self):
         super().close()
 
-        print("klive %s stopped" %version )
+        print("klive 0.2.2 stopped")
         if self.action is not None and not self.action._destroyed():
             self.action.icon = off
 

--- a/klayout/python/klive_server.py
+++ b/klayout/python/klive_server.py
@@ -52,7 +52,9 @@ class ServerInstance(pya.QTcpServer):
                 if connection.canReadLine():
                     line = connection.readLine()
                     data = json.loads(line)
+
                     # Interpret the data
+                    gds_path = data["gds"]
                     if "lyrdb" in data:
                         lyrdb_path = data["lyrdb"]
 


### PR DESCRIPTION
The purpose is to extend KLive functionality so that not only can you send the GDS file to KLayout for viewing, but you can also send the DRC or Functional Verification results for viewing. 

This adds an extra optional argument "lyrdb_filename", which is the file to show.

    show(file_gds,lyrdb_filename=file_lyrdb)


An example is shown here: https://github.com/SiEPIC/SiEPIC-Tools/blob/master/klayout_dot_config/python/SiEPIC/utils/klive.py

<img width="1396" alt="image" src="https://github.com/gdsfactory/klive/assets/15843200/eda14cd5-33d1-495d-bdf6-d59f58f3c969">
