### PR TITLE
Matching version formatting on closing klive

### DIFF
--- a/klayout/python/klive_server.py
+++ b/klayout/python/klive_server.py
@@ -172,7 +172,7 @@ class ServerInstance(pya.QTcpServer):
     def close(self):
         super().close()
 
-        print("klive 0.2.2 stopped")
+        print("klive v0.2.2 stopped")
         if self.action is not None and not self.action._destroyed():
             self.action.icon = off
 


### PR DESCRIPTION
Adjusts the following output

![image](https://github.com/gdsfactory/klive/assets/7860886/32271257-7280-40b9-988f-1b77ff8cbf76)


Closes #7 